### PR TITLE
Fix map focus for municipalities with abbreviated Boro/Twp names

### DIFF
--- a/www/src/county.test.ts
+++ b/www/src/county.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest"
+import { muniKey } from "./county"
+
+describe("muniKey", () => {
+    it("expands NJDOT's abbreviated suffixes to the full form", () => {
+        expect(muniKey("Hopewell Boro")).toBe("hopewell borough")
+        expect(muniKey("Hopewell Twp")).toBe("hopewell township")
+        expect(muniKey("Boro.")).toBe("borough")
+        expect(muniKey("Twp.")).toBe("township")
+    })
+
+    it("leaves already-canonical names unchanged (idempotent)", () => {
+        expect(muniKey("Hopewell Borough")).toBe("hopewell borough")
+        expect(muniKey("Hopewell Township")).toBe("hopewell township")
+        expect(muniKey("Pennington")).toBe("pennington")
+        expect(muniKey(muniKey("Hopewell Boro"))).toBe("hopewell borough")
+    })
+
+    it("makes the abbreviated and full spellings resolve to the same key", () => {
+        // This is the fix: muni-maps.json says "Hopewell Borough" while
+        // cc2mc2mn.json says "Hopewell Boro" — both must key identically.
+        expect(muniKey("Hopewell Boro")).toBe(muniKey("Hopewell Borough"))
+        expect(muniKey("Hopewell Twp")).toBe(muniKey("Hopewell Township"))
+    })
+
+    it("does not collide Borough and Township of the same town", () => {
+        // Expanding (not stripping) the suffix keeps them distinct.
+        expect(muniKey("Hopewell Borough")).not.toBe(muniKey("Hopewell Township"))
+        expect(muniKey("Hopewell Boro")).not.toBe(muniKey("Hopewell Twp"))
+    })
+
+    it("does not mangle 'boro'/'twp' embedded inside a name", () => {
+        // e.g. Marlboro (Monmouth) — 'boro' isn't a standalone suffix here.
+        expect(muniKey("Marlboro")).toBe("marlboro")
+        expect(muniKey("Marlboro Twp")).toBe("marlboro township")
+    })
+})

--- a/www/src/county.ts
+++ b/www/src/county.ts
@@ -7,3 +7,26 @@ export type CC2MC2MN = { [cc: number]: County }
 export const normalize = (s: string) => s.toLowerCase().replaceAll(' ', '-')
 
 export const denormalize = (s: string) => titleCase(s.replaceAll('-', ' '))
+
+/** Canonical key for matching a municipality name across data sources.
+ *
+ *  NJDOT abbreviates municipality suffixes ("Hopewell Boro", "Hopewell
+ *  Twp") while the map/GIS data (`muni-maps.json`, muni GeoJSON) spells
+ *  them out ("Hopewell Borough", "Hopewell Township"). The two disagree
+ *  for the same town, so the exact-string reverse lookups that turn a URL
+ *  slug back into an `mc` silently fail — e.g. picking "Hopewell Borough"
+ *  never resolves its code and the map won't focus. Pennington only works
+ *  because it happens to be spelled identically in both sources.
+ *
+ *  Fold both spellings to one key by *expanding* the abbreviations
+ *  (Boro→Borough, Twp→Township), never stripping the suffix — stripping
+ *  would collapse "Hopewell Borough" and "Hopewell Township" onto the same
+ *  key and collide two distinct municipalities. Lowercased and
+ *  whitespace-collapsed so it's safe to key on either the abbreviated or
+ *  the full form. */
+export const muniKey = (s: string): string =>
+    s.toLowerCase()
+        .replace(/\btwp\.?(?=\s|$)/g, 'township')
+        .replace(/\bboro\.?(?=\s|$)/g, 'borough')
+        .replace(/\s+/g, ' ')
+        .trim()

--- a/www/src/routes/CrashMapPage.tsx
+++ b/www/src/routes/CrashMapPage.tsx
@@ -15,7 +15,7 @@ import { useNavigate, useParams } from "react-router-dom"
 import { Head } from "@/src/lib/head"
 import { url } from "@/src/site"
 import { CrashMapSection } from "@/src/map/CrashMapSection"
-import { normalize } from "@/src/county"
+import { muniKey, normalize } from "@/src/county"
 
 // Local county-name → cc map (subset; full table in nj_crashes data files).
 const COUNTY_NAMES: Record<string, number> = {
@@ -37,9 +37,9 @@ function muniFromParam(cc: number | undefined, muni: string | undefined, lookup:
     if (!cc || !muni || !lookup) return undefined
     const mc2mn = lookup[String(cc)]?.mc2mn
     if (!mc2mn) return undefined
-    const norm = muni.toLowerCase().replace(/-/g, " ").replace(/\s+/g, " ").trim()
+    const key = muniKey(muni.replace(/-/g, " "))
     for (const [mc, name] of Object.entries(mc2mn)) {
-        if (name.toLowerCase() === norm) return Number(mc)
+        if (muniKey(name) === key) return Number(mc)
     }
     return undefined
 }

--- a/www/src/use-region.ts
+++ b/www/src/use-region.ts
@@ -1,4 +1,4 @@
-import { CC2MC2MN, County, denormalize, MC2MN, normalize } from "@/src/county";
+import { CC2MC2MN, County, denormalize, MC2MN, muniKey, normalize } from "@/src/county";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { keys, mapEntries } from "@rdub/base/objs";
 import { Arr } from "@rdub/base/arr";
@@ -48,8 +48,8 @@ export default function useRegion({ cc2mc2mn, urlPrefix, ...props }: {
                     setMc(null)
                 } else {
                     const { mc2mn } = cc2mc2mn[newCc]
-                    const mn2mc = mapEntries(mc2mn, (mc, mn) => [ mn, mc ])
-                    const newMc = mn2mc[mnPart]
+                    const mn2mc = mapEntries(mc2mn, (mc, mn) => [ muniKey(mn), mc ])
+                    const newMc = mn2mc[muniKey(mnPart)]
                     console.log(`setting mc ${newMc}`)
                     setMc(newMc)
                 }


### PR DESCRIPTION
## Problem

Selecting a municipality whose NJDOT name is abbreviated — e.g. **Hopewell Borough** or **Hopewell Township** in Mercer — doesn't focus the map on it. **Pennington** (same county) works fine.

## Root cause

Two data sources spell the same municipality differently:

- `muni-maps.json` (drives the `MuniPicker` options and their links) uses the **canonical** names: `"Hopewell Borough"`, `"Hopewell Township"`, `"Pennington"`.
- `cc2mc2mn.json` (the `mc`↔name table the reverse lookups match against) uses NJDOT's **abbreviated** names: `"Hopewell Boro"`, `"Hopewell Twp"`, `"Pennington"`.

The picker links to `/c/mercer/hopewell-borough`; the resolvers (`use-region.ts` `updateCodes` and `CrashMapPage.tsx` `muniFromParam`) `denormalize` that slug back to `"Hopewell Borough"` and do an exact-string compare against the `cc2mc2mn` names — which say `"Hopewell Boro"`. No match → `mc` stays `undefined` → the map falls back to the county view instead of focusing on the muni. Pennington works only because it happens to be spelled identically in both files.

The geometry is fine — `muni_bboxes["11-5"]`/`["11-6"]` and the features in `munis/11.geojson` all exist; it's purely the name match that fails. This affects **every abbreviated-suffix municipality statewide**, not just Hopewell.

## Fix

Add `muniKey()` in `county.ts` — a small canonicalizer that folds both spellings to one key by **expanding** the suffix (`Boro`→`Borough`, `Twp`→`Township`) rather than stripping it. Stripping would collapse `"Hopewell Borough"` and `"Hopewell Township"` onto the same key and collide two distinct municipalities; expanding keeps them distinct. Both reverse lookups now route through it, so slugs built from either spelling resolve to the right `mc`.

## Tests

Adds `county.test.ts` covering suffix expansion, idempotence on already-canonical names, the `Boro`≡`Borough` / `Twp`≡`Township` equivalence (the actual fix), collision-avoidance between Borough and Township, and that an embedded substring like `Marlboro` isn't mangled. The `muniKey` logic was also validated against the real Mercer names.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
